### PR TITLE
feat(log): add HOBOM_ANGEL to ServiceType enum

### DIFF
--- a/src/main/kotlin/com/hobom/hobominternal/domain/log/model/ServiceType.kt
+++ b/src/main/kotlin/com/hobom/hobominternal/domain/log/model/ServiceType.kt
@@ -10,6 +10,7 @@ enum class ServiceType(
     HOBOM_API_GATEWAY("HOBOM_API_GATEWAY", "hobom-api-gateway"),
     HOBOM_MESSAGE_DELIVERY("HOBOM_MESSAGE_DELIVERY", "hobom-message-delivery"),
     HOBOM_SPACE("HOBOM_SPACE", "hobom-space-backend"),
+    HOBOM_ANGEL("HOBOM_ANGEL", "for-hobom-angel-backend"),
     ;
 
     override fun toString(): String = value


### PR DESCRIPTION
hobom-event-processor now relays `for-hobom-angel-backend`'s access logs to `hobom.logs` tagged `serviceType: HOBOM_ANGEL`. The consumer's `ServiceType` enum lacked this value, so the log failed to deserialize (`not one of the values accepted for Enum class`) and never persisted.

Adds `HOBOM_ANGEL("HOBOM_ANGEL", "for-hobom-angel-backend")`, matching the `HOBOM_*` convention. Paired with the processor fix that sends `HOBOM_ANGEL` (was `ANGEL`). `compileKotlin` passes.